### PR TITLE
Flash 支持和分类入口更新

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -3,4 +3,4 @@
 
 [点击此处](https://upclinux.github.io)访问博客。
 
-博客通过[Grunt](http://gruntjs.com/)生成和部署。切换到`dev`分支来查看源代码。
+博客通过 GitHub Action 生成和部署，一般情况下你无需下载和修改本分支。切换到`dev`分支来查看源代码。

--- a/app/_includes/header.html
+++ b/app/_includes/header.html
@@ -28,7 +28,7 @@
                         </a>
                         <ul class="dropdown-menu" role="menu">
                             <li>
-                                <a href="{{ "/categories/?c=All" | prepend: site.baseurl }}">
+                                <a href="{{ "/categories/?c=全部文章" | prepend: site.baseurl }}">
                                     <span class="badge" style="float:right;">
                                         {{ site.posts | size }}
                                     </span>

--- a/app/_posts/2015-06-06-freemind.markdown
+++ b/app/_posts/2015-06-06-freemind.markdown
@@ -20,20 +20,29 @@ tags: Freemind
 
 如果看着不方便，可以<a href="/js/2015-06-06-freemind/view.html" target="_blank">点这里</a>。
 
-<script src="/js/2015-06-06-freemind/flashobject.js"></script>
-<div id="flashcontent" style="height: 500px;">
-[需要 Flash 和 JavaScript]
-</div>
+<script src="https://unpkg.com/@ruffle-rs/ruffle"></script>
+<div id="flashcontent" style="height: 500px;">正在加载中……如果耗时过长，请检查网络环境和浏览器。</div>
 <script>
-var fo = new FlashObject("/js/2015-06-06-freemind/visorFreemind.swf", "visorFreeMind", "100%", "100%", 8, "#9999ff");
-fo.addParam("quality", "high");
-fo.addParam("bgcolor", "#ffffff");
-fo.addParam("allowScriptAccess", "true");
-fo.addVariable("openUrl", "_blank");
-fo.addVariable("initLoadFile", "/js/2015-06-06-freemind/map.mm");
-fo.addVariable("startCollapsedToLevel","5");
-fo.write("flashcontent");
+window.addEventListener('load', () => {
+    const flashContent = document.getElementById('flashcontent');
+    window.RufflePlayer.config = {
+        autoplay: "on"
+    }
+    const ruffle = window.RufflePlayer.newest();
+    const player = ruffle.createPlayer();
+
+    flashContent.innerHTML = "";
+
+    flashContent.appendChild(player);
+    player.ruffle().load("/js/2015-06-06-freemind/visorFreemind.swf?openUrl='_blank'&initLoadFile=/js/2015-06-06-freemind/map.mm&startCollapsedToLevel");
+});
 </script>
+
+{% callout %}
+大多数主流浏览器应该都已经停止支持 Flash Player 了，为了能够保证思维导图能够正常显示，本博客将暂时使用 Ruffle 作为过渡方案。
+{% endcallout %}
+
+修改说明
 
 做个总结——什么情况下能够很涨姿势呢？
 

--- a/app/js/2015-06-06-freemind/view.html
+++ b/app/js/2015-06-06-freemind/view.html
@@ -1,34 +1,52 @@
 <!DOCTYPE html>
 <html>
-<head><meta content="text/html; charset=UTF-8" http-equiv="Content-Type" /><title>某会长的经历</title>
-<script type="text/javascript" src="flashobject.js"></script>
-<style type="text/css"> 
-html {
-    height: 100%;
-    overflow: hidden;
-}
-#flashcontent {
-    height: 100%;
-}
-body {
-    height: 100%;
-    margin: 0;
-    padding: 0;
-    background-color: #9999ff;
-}
-</style>
+<head>
+    <meta content="text/html; charset=UTF-8" http-equiv="Content-Type" />
+    <title>某会长的经历</title>
+    <style type="text/css"> 
+        html {
+            height: 100%;
+            overflow: hidden;
+        }
+        #flashcontent {
+            height: 100%;
+            width: 100%;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+        }
+        body {
+            height: 100%;
+            margin: 0;
+            padding: 0;
+            background-color: #9999ff;
+        }
+    </style>
 </head>
 <body>
-<div id="flashcontent">需要 Flash 和 JavaScript</div>
-<script type="text/javascript">
-var fo = new FlashObject("visorFreemind.swf", "visorFreeMind", "100%", "100%", 8, "#9999ff");
-fo.addParam("quality", "high");
-fo.addParam("bgcolor", "#ffffff");
-fo.addParam("allowScriptAccess", "true");
-fo.addVariable("openUrl", "_blank");
-fo.addVariable("initLoadFile", "map.mm");
-fo.addVariable("startCollapsedToLevel","5");
-fo.write("flashcontent");
-</script>
+    <div id="flashcontent">正在加载中……如果耗时过长，请检查网络环境和浏览器。</div>
+    <script src="https://unpkg.com/@ruffle-rs/ruffle"></script>
+    <script>
+        window.addEventListener('load', () => {
+            window.RufflePlayer.config = {
+                autoplay: "on"
+            }
+            const ruffle = window.RufflePlayer.newest();
+            const player = ruffle.createPlayer();
+            const flashContent = document.getElementById('flashcontent');            
+            player.style.position = 'fixed';
+            player.style.top = '50%';
+            player.style.left = '50%';
+            player.style.transform = 'translate(-50%, -50%)';
+            player.style.width = '100%';
+            player.style.height = '100%';
+            player.style.zIndex = '1000';
+            player.style.backgroundColor = 'black';
+            player.style.boxShadow = '0 0 10px rgba(0, 0, 0, 0.5)';
+            player.style.margin = '0px';
+            flashContent.appendChild(player);
+            player.ruffle().load("visorFreemind.swf?openUrl='_blank'&initLoadFile=/js/2015-06-06-freemind/map.mm&startCollapsedToLevel");
+        });
+    </script>
 </body>
 </html>


### PR DESCRIPTION
- 修复了下拉菜单中“全部文章”的错误入口

![image](https://github.com/user-attachments/assets/5fedf25e-67dd-48d5-ae7e-4c0a93f38be4)

- 修复了“[某会长是如何接触 Linux](https://upclinux.github.io/2015/06/06/freemind/)”章节中的 Flash 播放问题，现在引入 Ruffle 播放器作为临时替代方案